### PR TITLE
버그 수정

### DIFF
--- a/lecture_viewer.py
+++ b/lecture_viewer.py
@@ -57,15 +57,17 @@ class LectureViewer:
             return False
 
     def __play(self) -> bool:
+        success = True
         try:
             iframe = self.driver.find_element(By.TAG_NAME, "iframe")
             self.driver.switch_to.frame(iframe)
             self.driver.find_element(By.CLASS_NAME, "vc-front-screen-play-btn").click()
             self.__mute()
-            self.driver.switch_to.default_content()
-            return True
         except NoSuchElementException:
-            return False
+            success = False
+        finally:
+            self.driver.switch_to.default_content()
+            return success
 
     def __wait(self, title, cur, tot) -> bool:
         for _ in trange(


### PR DESCRIPTION
```py
iframe = self.driver.find_element(By.TAG_NAME, "iframe")
self.driver.switch_to.frame(iframe)
self.driver.find_element(By.CLASS_NAME, "vc-front-screen-play-btn").click()
self.__mute()
self.driver.switch_to.default_content()
```

`vc-front-screen-play-btn` 클래스의 버튼을 찾지 못해 예외가 발생할 경우
기본 프레임으로 다시 돌려놓지 않아 이후 닫기 버튼을 찾지 못하는 버그 수정

close #3 